### PR TITLE
fix mask resizing bug

### DIFF
--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -34,7 +34,7 @@ except ImportError:
                 newshape = (newsize[0],newsize[1])
                 
             pilim = Image.fromarray(pic)
-            resized_pil = pilim.resize(newsize[::-1], Image.ANTIALIAS)
+            resized_pil = pilim.resize(newsize[::-1], Image.BICUBIC)
             #arr = np.fromstring(resized_pil.tostring(), dtype='uint8')
             #arr.reshape(newshape)
             return np.array(resized_pil)

--- a/moviepy/video/fx/resize.py
+++ b/moviepy/video/fx/resize.py
@@ -155,8 +155,10 @@ def resize(clip, newsize=None, height=None, width=None, apply_to_mask=True,
                 fun = lambda gf,t: resizer(gf(t).astype('uint8'),
                                           newsize2(t))
                 
-            return clip.fl(fun, keep_duration=True,
-                           apply_to= (["mask"] if apply_to_mask else []))
+            if apply_to_mask and clip.mask is not None:
+                clip.mask = resize(clip.mask, newsize, apply_to_mask=False)
+
+            return clip.fl(fun, keep_duration=True)
             
         else:
             


### PR DESCRIPTION
Using dynamic resizing ( lambda t: f(t) ) with mask will fail
Mask should be floating points but become uint8 instead after resizing